### PR TITLE
Security Fixes for Go Vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module toodeloo
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
+	golang.org/x/net v0.38.0
 )
 
 require (
@@ -15,7 +16,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 )


### PR DESCRIPTION
This PR addresses 3 vulnerabilities found in the Go codebase. The Go version has been updated to 1.24.4 to fix syscall and crypto/x509 vulnerabilities. The golang.org/x/net package has been updated to v0.38.0 to fix an HTML injection vulnerability.