### PR TITLE
Security Fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module toodeloo
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1
@@ -15,7 +15,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 )


### PR DESCRIPTION
This PR addresses 3 security vulnerabilities found in the Go codebase. The Go version has been updated to 1.24.4 to fix syscall and crypto/x509 vulnerabilities. The golang.org/x/net package has been updated to v0.38.0 to fix an HTML injection vulnerability.